### PR TITLE
refactor: moved purchasing an item into store

### DIFF
--- a/src/components/category-item.js
+++ b/src/components/category-item.js
@@ -1,8 +1,7 @@
-import { useCallback, useState } from "@wordpress/element";
+import { useCallback } from "@wordpress/element";
 
 import { STORE_NAME } from "../store";
 import { useSelect, dispatch } from "@wordpress/data";
-import apiFetch from "@wordpress/api-fetch";
 
 import priceTag from "./category-item-pricetag.svg";
 import "./category-item.scss";
@@ -18,32 +17,14 @@ export default function CategoryItem({ selectedCategory, item }) {
 		};
 	});
 
-	const shopping = async (item_data, category) => {
-		const success = apiFetch({
-			path: `${restBase}/purchases`,
-			method: 'POST',
-			data: {
-				item: {
-					key: item_data.meta.key,
-					price: item_data.meta.price,
-				}},
-		});
-
-		return success;
-	}
-
-	const __handleItem = async () => {
+	const __handleItem = () => {
 		const data_key = item.meta.key;
 
 		if (items[selectedCategory] && items[selectedCategory][data_key]) {
 			let item_data = items[selectedCategory][data_key];
 			if ( item_data.meta?.price > 0 ) {
 				if( item_data.meta.price <= balance ) {
-					if(await shopping(item_data, selectedCategory)) {
-						dispatch(STORE_NAME).setBalance(balance - item_data.meta.price);
-						item_data.meta.price = 0;
-						dispatch(STORE_NAME).setItems(items);
-					}
+					dispatch(STORE_NAME).purchaseItem(item_data);
 				}
 			} else {
 				const category_data = wapuu.char[selectedCategory];


### PR DESCRIPTION
Done.

@DerHerrFeldmann : i am not sure if your approach (=> setting the item price to zero on purchase) is a good solution : 

(1) items will be rendered in different order after a purchase since items are ordered by price. 

example: if the item with the highest price (rendered as last one because sorted by price) was purchased, it will be rendered afterwards BEFORE the first item having a price > 0

(2) user will likely see what items they already purchased. that's not possible using the current solution. 

it would be better to add an additional property "purchased" to the items in the front end. using this property 

- rendering the item position would be the same before and after purchasing an item.

- items can be visually marked as "purchased"

My 5 cents.