### PR TITLE
feat(#184): warn user when password appears in HaveIBeenPwned

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "thursday"
+      time: "23:00"
+      timezone: "Europe/Berlin"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -14,7 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "thursday"
+      time: "23:00"
+      timezone: "Europe/Berlin"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,22 +3,22 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "dependencies"
     schedule:
-      interval: "weekly"
-      day: "thursday"
+      interval: "daily"
       time: "23:00"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dependencies"
     schedule:
-      interval: "weekly"
-      day: "thursday"
+      interval: "daily"
       time: "23:00"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,21 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches:
+      - dependencies
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/inc/alive/Manager.php
+++ b/inc/alive/Manager.php
@@ -33,14 +33,7 @@ class Manager {
 	 * This method initializes the Manager class by adding the necessary filters and actions.
 	 */
 	public function __construct() {
-		\add_filter( 'wapuugotchi_register_settings', array( $this, 'register_setting' ) );
 		\add_filter( 'wapuugotchi_avatar', array( AnimationHandler::class, 'extract_animations' ), PHP_INT_MAX, 1 );
-
-		$settings = \get_option( 'wapuugotchi_settings', array() );
-		if ( ( $settings['alive'] ?? true ) === false ) {
-			return;
-		}
-
 		\add_action( 'animations_extracted', array( $this, 'add_animations' ) );
 	}
 
@@ -70,23 +63,5 @@ class Manager {
 			},
 			20
 		);
-	}
-
-	/**
-	 * Register this feature in the settings page.
-	 *
-	 * @param array $features Registered features.
-	 *
-	 * @return array
-	 */
-	public function register_setting( $features ) {
-		$features[] = array(
-			'key'         => 'alive',
-			'label'       => \__( 'Alive Animations', 'wapuugotchi' ),
-			'description' => \__( 'Your Wapuu brings the dashboard to life with random animations based on the items it is currently wearing.', 'wapuugotchi' ),
-			'default'     => true,
-		);
-
-		return $features;
 	}
 }

--- a/inc/buddy/Manager.php
+++ b/inc/buddy/Manager.php
@@ -44,8 +44,8 @@ class Manager {
 		$features[] = array(
 			'key'         => 'feed',
 			'label'       => \__( 'News Feed', 'wapuugotchi' ),
-			'description' => \__( "Your Wapuu keeps you up to date with everything happening in the WordPress universe — from upcoming releases to community highlights. Stay curious!\nIt fetches this content via our feed service (feed.wapuugotchi.com).\nWe don't collect or store your data — it's yours, and we keep it that way.", 'wapuugotchi' ),
-			'default'     => false,
+			'description' => \__( "Your Wapuu keeps you up to date with everything happening in the WordPress universe — from upcoming releases to community highlights.\nIt fetches this content via our feed service (feed.wapuugotchi.com). What you read stays between you and your Wapuu.", 'wapuugotchi' ),
+			'default'     => true,
 		);
 
 		return $features;

--- a/inc/security/Api.php
+++ b/inc/security/Api.php
@@ -18,7 +18,7 @@ class Api {
 	/**
 	 * External API endpoint.
 	 */
-	const API_URL = 'https://vulnerability.wapuugotchi.com/api/vulns-batch';
+	const API_URL = 'https://security.wapuugotchi.com/api/vulns-batch.php';
 
 	/**
 	 * Query the remote vulnerability API.

--- a/inc/security/Manager.php
+++ b/inc/security/Manager.php
@@ -8,7 +8,9 @@
 namespace Wapuugotchi\Security;
 
 use Wapuugotchi\Security\Data\AutoMessage;
+use Wapuugotchi\Security\Data\PwnedMessage;
 use Wapuugotchi\Security\Handler\CheckHandler;
+use Wapuugotchi\Security\Handler\PwnedHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit();
@@ -31,6 +33,11 @@ class Manager {
 
 		\add_action( 'load-index.php', array( CheckHandler::class, 'maybe_run_daily_security_check' ) );
 		\add_filter( 'wapuugotchi_bubble_messages', array( AutoMessage::class, 'add_security_messages_filter' ), 100, 1 );
+
+		if ( ( $settings['hibp'] ?? false ) !== false ) {
+			\add_filter( 'authenticate', array( PwnedHandler::class, 'maybe_check_at_login' ), PHP_INT_MAX, 3 );
+			\add_filter( 'wapuugotchi_bubble_messages', array( PwnedMessage::class, 'add_pwned_message_filter' ), 110, 1 );
+		}
 	}
 
 	/**
@@ -43,8 +50,15 @@ class Manager {
 	public function register_setting( $features ) {
 		$features[] = array(
 			'key'         => 'security',
-			'label'       => \__( 'Security Messages', 'wapuugotchi' ),
-			'description' => \__( "Your Wapuu performs daily security checks and notifies you if any issues are found. It also shares helpful security tips.\nTo run vulnerability checks, it securely connects to our service (vulnerability.wapuugotchi.com).\nYour data stays yours — we don't access or store your personal content.", 'wapuugotchi' ),
+			'label'       => \__( 'Plugin Vulnerabilities', 'wapuugotchi' ),
+			'description' => \__( "Your Wapuu performs daily security checks on your installed plugins and warns you if any known vulnerabilities are found.\nWe handle this through our service (security.wapuugotchi.com) — we don't track, log, or store anything about your site. Your site, your data — we only check, never collect.", 'wapuugotchi' ),
+			'default'     => true,
+		);
+
+		$features[] = array(
+			'key'         => 'hibp',
+			'label'       => \__( 'Password Breach Check', 'wapuugotchi' ),
+			'description' => \__( "Your Wapuu checks whether your password has appeared in a known data breach and warns you on every login if so.\nWe handle this through our service (security.wapuugotchi.com) — designed so your password never leaves your system. Your data is yours.", 'wapuugotchi' ),
 			'default'     => false,
 		);
 

--- a/inc/security/Meta.php
+++ b/inc/security/Meta.php
@@ -29,4 +29,9 @@ class Meta {
 	 * User meta key storing dismissed security message ids for the current day.
 	 */
 	const DISMISSED_META_KEY = 'wapuugotchi_security_dismissed_messages';
+
+	/**
+	 * User meta key storing the result of the last HaveIBeenPwned check.
+	 */
+	const PWNED_RESULT_META_KEY = 'wapuugotchi_security_pwned_result';
 }

--- a/inc/security/data/PwnedMessage.php
+++ b/inc/security/data/PwnedMessage.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * The PwnedMessage Class.
+ *
+ * @package WapuuGotchi
+ */
+
+namespace Wapuugotchi\Security\Data;
+
+use Wapuugotchi\Avatar\Models\Message;
+use Wapuugotchi\Security\Handler\MessageHandler;
+use Wapuugotchi\Security\Meta;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+/**
+ * Builds the HaveIBeenPwned warning bubble message.
+ */
+class PwnedMessage {
+
+	/**
+	 * Unique message identifier used for dismissal tracking.
+	 */
+	const MESSAGE_ID = 'security-pwned';
+
+	/**
+	 * Add a pwned-password warning to the bubble if the last HIBP check flagged the user.
+	 *
+	 * @param array $messages Existing messages.
+	 *
+	 * @return array
+	 */
+	public static function add_pwned_message_filter( $messages ) {
+		if ( ! \current_user_can( 'update_plugins' ) ) {
+			return $messages;
+		}
+
+		$user_id = \get_current_user_id();
+		if ( ! $user_id ) {
+			return $messages;
+		}
+
+		if ( ! \get_user_meta( $user_id, Meta::PWNED_RESULT_META_KEY, true ) ) {
+			return $messages;
+		}
+
+		$message_id = self::MESSAGE_ID;
+
+		$messages[] = new Message(
+			$message_id,
+			self::get_random_warning(),
+			'security-critical',
+			function () use ( $message_id ) {
+				return MessageHandler::is_active( $message_id );
+			},
+			function () use ( $message_id ) {
+				return MessageHandler::handle_submit( $message_id );
+			}
+		);
+
+		return $messages;
+	}
+
+	/**
+	 * Return one of four random warning messages.
+	 *
+	 * @return string
+	 */
+	private static function get_random_warning() {
+		$warnings = array(
+			\__( '<strong>⚠ We have a problem!</strong> Our password has shown up in a public data breach — attackers may already have it. We need to change it immediately!', 'wapuugotchi' ),
+			\__( '<strong>⚠ We are in danger!</strong> Our password is on a known list of stolen credentials. The bad guys could use it to break into our account — we have to act right now!', 'wapuugotchi' ),
+			\__( '<strong>⚠ We need to act!</strong> Our password was leaked in a data breach. Anyone with that list is able to attack us — let\'s change it today before it\'s too late!', 'wapuugotchi' ),
+			\__( '<strong>⚠ This is serious!</strong> Our password was found in a breach database. Attackers are out there and could use it against us — we must update it immediately!', 'wapuugotchi' ),
+		);
+
+		return $warnings[ \array_rand( $warnings ) ];
+	}
+}

--- a/inc/security/handler/PwnedHandler.php
+++ b/inc/security/handler/PwnedHandler.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * The PwnedHandler Class.
+ *
+ * @package WapuuGotchi
+ */
+
+namespace Wapuugotchi\Security\Handler;
+
+use Wapuugotchi\Security\Meta;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+/**
+ * Checks the user's password against the HaveIBeenPwned k-Anonymity API at login.
+ *
+ * Only the first 5 characters of the SHA-1 hash are transmitted — the full
+ * password and the full hash never leave the server.
+ */
+class PwnedHandler {
+
+	/**
+	 * WapuuGotchi Security relay endpoint for HIBP range lookups.
+	 */
+	const HIBP_API_URL = 'https://security.wapuugotchi.com/api/check.php';
+
+	/**
+	 * Run the HIBP check after a successful login.
+	 *
+	 * Hooked into the 'authenticate' filter at PHP_INT_MAX so that $user is
+	 * already resolved to a WP_User on success. Runs at most once per day.
+	 *
+	 * @param \WP_User|\WP_Error|null $user     Resolved authentication result.
+	 * @param string                  $username Username (unused).
+	 * @param string                  $password Plaintext password from the login form.
+	 *
+	 * @return \WP_User|\WP_Error|null Unchanged — this handler never modifies the result.
+	 */
+	public static function maybe_check_at_login( $user, $username, $password ) {
+		if ( ! ( $user instanceof \WP_User ) || empty( $password ) ) {
+			return $user;
+		}
+
+		$user_id = $user->ID;
+		$hash    = \strtoupper( \sha1( $password ) );
+		$prefix  = \substr( $hash, 0, 5 );
+		$suffix  = \substr( $hash, 5 );
+
+		$response = \wp_remote_get(
+			\add_query_arg( 'prefix', $prefix, self::HIBP_API_URL ),
+			array(
+				'timeout'    => 5,
+				'user-agent' => 'WapuuGotchi WordPress Plugin (https://wapuugotchi.com)',
+			)
+		);
+
+		if ( \is_wp_error( $response ) || 200 !== \wp_remote_retrieve_response_code( $response ) ) {
+			return $user;
+		}
+
+		$pwned = \stripos( \wp_remote_retrieve_body( $response ), $suffix . ':' ) !== false;
+
+		\update_user_meta( $user_id, Meta::PWNED_RESULT_META_KEY, $pwned );
+
+		if ( $pwned ) {
+			$today = \wp_date( 'Y-m-d' );
+			$meta  = \get_user_meta( $user_id, Meta::DISMISSED_META_KEY, true );
+			if ( \is_array( $meta ) && ( $meta['date'] ?? '' ) === $today ) {
+				$meta['ids'] = \array_values( \array_diff( $meta['ids'] ?? array(), array( 'security-pwned' ) ) );
+				\update_user_meta( $user_id, Meta::DISMISSED_META_KEY, $meta );
+			}
+		}
+
+		return $user;
+	}
+}

--- a/languages/wapuugotchi-local-de_DE.po
+++ b/languages/wapuugotchi-local-de_DE.po
@@ -2929,3 +2929,27 @@ msgstr "Ihre Perlenbilanz:"
 #: inc/shop/src/components/payment-dialog.js:56
 msgid "Do you want to buy this item?"
 msgstr "Möchten Sie diesen Artikel kaufen?"
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ We have a problem!</strong> Our password has shown up in a public data breach — attackers may already have it. We need to change it immediately!"
+msgstr "<strong>⚠ Wir haben ein Problem!</strong> Unser Passwort ist in einem öffentlichen Datenleck aufgetaucht — Angreifer könnten es bereits haben. Wir müssen es sofort ändern!"
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ We are in danger!</strong> Our password is on a known list of stolen credentials. The bad guys could use it to break into our account — we have to act right now!"
+msgstr "<strong>⚠ Wir sind in Gefahr!</strong> Unser Passwort steht auf einer bekannten Liste gestohlener Zugangsdaten. Die Bösewichte könnten es nutzen, um in unser Konto einzudringen — wir müssen jetzt handeln!"
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ We need to act!</strong> Our password was leaked in a data breach. Anyone with that list is able to attack us — let's change it today before it's too late!"
+msgstr "<strong>⚠ Wir müssen handeln!</strong> Unser Passwort wurde in einem Datenleck veröffentlicht. Jeder mit dieser Liste kann uns angreifen — lass es uns noch heute ändern, bevor es zu spät ist!"
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ This is serious!</strong> Our password was found in a breach database. Attackers are out there and could use it against us — we must update it immediately!"
+msgstr "<strong>⚠ Das ist ernst!</strong> Unser Passwort wurde in einer Leak-Datenbank gefunden. Angreifer sind da draußen und könnten es gegen uns verwenden — wir müssen es sofort aktualisieren!"
+
+#: inc/security/Manager.php
+msgid "Pwned Password Check"
+msgstr "Passwort-Sicherheitscheck"
+
+#: inc/security/Manager.php
+msgid "Your Wapuu checks whether your password has appeared in a known data breach and warns you once a day if so.\nIt uses the HaveIBeenPwned k-Anonymity API — only the first 5 characters of a SHA-1 hash are transmitted, never your password itself."
+msgstr "Dein Wapuu prüft, ob dein Passwort in einem bekannten Datenleck aufgetaucht ist, und warnt dich einmal täglich.\nEs wird die HaveIBeenPwned k-Anonymity-API verwendet — nur die ersten 5 Zeichen eines SHA-1-Hashes werden übertragen, niemals dein Passwort selbst."

--- a/languages/wapuugotchi-local.pot
+++ b/languages/wapuugotchi-local.pot
@@ -2928,3 +2928,27 @@ msgstr ""
 #: inc/shop/src/components/payment-dialog.js:56
 msgid "Do you want to buy this item?"
 msgstr ""
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ We have a problem!</strong> Our password has shown up in a public data breach — attackers may already have it. We need to change it immediately!"
+msgstr ""
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ We are in danger!</strong> Our password is on a known list of stolen credentials. The bad guys could use it to break into our account — we have to act right now!"
+msgstr ""
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ We need to act!</strong> Our password was leaked in a data breach. Anyone with that list is able to attack us — let's change it today before it's too late!"
+msgstr ""
+
+#: inc/security/data/PwnedMessage.php
+msgid "<strong>⚠ This is serious!</strong> Our password was found in a breach database. Attackers are out there and could use it against us — we must update it immediately!"
+msgstr ""
+
+#: inc/security/Manager.php
+msgid "Pwned Password Check"
+msgstr ""
+
+#: inc/security/Manager.php
+msgid "Your Wapuu checks whether your password has appeared in a known data breach and warns you once a day if so.\nIt uses the HaveIBeenPwned k-Anonymity API — only the first 5 characters of a SHA-1 hash are transmitted, never your password itself."
+msgstr ""


### PR DESCRIPTION
Hooks into the 'authenticate' filter at PHP_INT_MAX to intercept the plaintext password after a successful login. Uses the HIBP k-Anonymity range API — only the first 5 characters of the SHA-1 hash are sent, the full password and hash never leave the server.

Result is cached in user meta (wapuugotchi_security_pwned_result) and only re-checked once per day per user. If flagged, Wapuu shows one of four random critical-severity bubble messages, once per day, using the existing MessageHandler dismissal system.

Gated behind the existing 'security' feature toggle in settings.